### PR TITLE
Modified URL to Pure-converter

### DIFF
--- a/publications.md
+++ b/publications.md
@@ -15,7 +15,7 @@ The [SERG Dissertation Series](phd.html) includes the dissertations written by S
 
 <script language="javascript">
 
-  var purexml_SERG = "https://purexml-dev.ewi.tudelft.nl/direct/tu/group/d40bac4b-3dd0-4427-aa5f-9331cae5d02e";
+  var purexml_SERG = "https://purexml-open.ewi.tudelft.nl/direct/tu/group/d40bac4b-3dd0-4427-aa5f-9331cae5d02e";
   var page_nr = location.search;
 
   var xhttp = new XMLHttpRequest();


### PR DESCRIPTION
**purexml-open** is a clone of the **purexml-dev** and is using the original version of the pure-converter.

purexml-dev is used now for testing version 2 of the pure-converter.