### PR TITLE
msc topics: add ml4se

### DIFF
--- a/msctopics/_posts/2020-02-03-software-engineering-for-machine-learning.md
+++ b/msctopics/_posts/2020-02-03-software-engineering-for-machine-learning.md
@@ -1,0 +1,32 @@
+---
+layout: page
+title: Software Engineering for Machine Learning
+categories: [msc-topics]
+where: TU Delft
+contact: Luís Cruz, Arie van Deursen
+---
+
+#### Project description
+
+Many organisations are currently putting considerable effort into defining better and efficient Machine Learning (ML) development processes.
+However, there is still a lack of standards and the number of technologies out there is overwhelming.
+
+The long term goal of this project is to guide practitioners to build maintainable ML projects.
+This problem needs to be addressed at different stages of an ML lifecycle -- from the definition of the ML problem to its deployment in production (and so on). 
+
+In TU Delft we are already undertaking a case study with industry partners. If
+you want to know more, feel free to contact Luís or Arie.
+
+#### Further Reading
+
+- P. Heck, [Software Engineering for Machine Learning Applications](https://fontysblogt.nl/software-engineering-for-machine-learning-applications/). Online, 2019.
+- D. Sculley, et al., [Hidden Technical Debt in Machine Learning Systems](https://papers.nips.cc/paper/5656-hidden-technical-debt-in-machine-learning-systems.pdhttp:/martin.zinkevich.org/rules_of_ml/rules_of_ml). NIPS, 2015, p. 2494-2502.
+- S. Amershi, A. Begel, C. Bird, R. DeLine, H Gall, K. Kamar, N. Nagappan, B. Nushi, T. Zimmermann,
+[Software Engineering for Machine Learning: A Case Study](https://www.microsoft.com/en-us/research/publication/software-engineering-for-machine-learning-a-case-study/). 2019 IEEE/ACM 41st International Conference on Software Engineering: Software Engineering in Practice (ICSE-SEIP). IEEE, 2019.
+- Tim Menzies, [The Five Laws of SE for AI](https://ieeexplore.ieee.org/document/8938116). Software IEEE, vol. 37, no. 1, pp. 81-85, 2020.
+- [Awesome List Software Engineering for Machine Learning](https://github.com/SE-ML/awesome-seml)
+
+#### Contacts about the project:
+
+* [Luís Cruz](mailto:L.Cruz@tudelft.nl) (TU Delft)
+* [Arie van Deursen](mailto:arie.vandeursen@tudelft.nl) (TU Delft)


### PR DESCRIPTION
Adds a new topic for MSc.

Note: I cannot render the info page with the local web server (e.g., https://se.ewi.tudelft.nl/msctopics/msc-topics/2019/10/refactoring)
I am building the website using the docker cmd. Since this happens for all the MSc info pages and not only for the one  I've added, I'm assuming this is a problem with the setup and not with my changes.