### PR TITLE
identify ics events through full page id

### DIFF
--- a/serg-events.ics
+++ b/serg-events.ics
@@ -27,7 +27,7 @@ END:STANDARD
 END:VTIMEZONE
 {% assign items = site.events | reverse %}
 {% for post in items limit:30 %}BEGIN:VEVENT
-UID:{{ post.date | date: "%Y%m%d" }}@se.ewi.tudelft.nl
+UID:{{ post.id | slugify }}@se.ewi.tudelft.nl
 ORGANIZER;CN="SERG":MAILTO:noreply@se.ewi.tudelft.nl
 LOCATION:{{ post.where }}
 SUMMARY:{{ post.speaker }}: {{ post.title }}


### PR DESCRIPTION
e.g. for the newest reading club the uid will be:
`events-2020-09-09-reading-club-building-theories-se@se.ewi.tudelft.nl`
making them unique for unique event names on a day 🙂

Or should we rather look for a proper random number plugin alltogether?