### PR TITLE
Add mark swillus

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+if has nix; then
+    use nix
+fi

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
     <meta name="author" content="{{ site.author.name }}">
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" integrity="sha384-+d0P83n9kaQMCwj8F4RJB66tzIwOKmrdb46+porD/OvrJ+37WqIM7UoBtwHO6Nlg" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css" integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous">
 
     <link rel="stylesheet" href="/css/academicons.min.css"/>
     <link rel="stylesheet" href="/css/serg.css">

--- a/people.md
+++ b/people.md
@@ -468,6 +468,18 @@ title: People
     </div>
   </div>
 
+  <div class="card d-flex d-block">
+    <img class="card-img-top" src="https://avatars.githubusercontent.com/u/81824608?v=4" alt="Mark Swillus">
+    <div class="card-body">
+      <div class="card-title">Mark Swillus</div>
+      <p class="card-text">Socio-technical enablers/inhibitors of software testing</a></p>
+    </div>
+    <div class="card-footer bg-transparent border-success">
+      <a href="https://github.com/mswillus"><i class="fab fa-github"></i></a>
+      <a href="https://scholar.social/web/accounts/215562"><i class="fab fa-mastodon"></i></a>
+    </div>
+  </div>
+
 </div>
 
 ### Scientific Programmers

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    ruby_2_7
+    bundix
+  ];
+  }


### PR DESCRIPTION
The first commit defines dependencies declarative. With `direnv` and `nix` installed on a system, requirements will be installed automatically after `cd`-ing into the folder and enabling direnv with `direnv allow`. When `cd`-ing out of the folder the packages declared in `shell.nix` will be unloaded. This ensures that the correct version of bundler and ruby is used independent of the version installed on the machine.

If this change is not wanted, let me know and I will remove the commit and add entries to the `.gitignore` file instead.

More info at: https://nixos.org/guides/ad-hoc-developer-environments.html

I also updated the font awesome version to 5.8.2 which is the first version that supports the mastodon icon.