### PR TITLE
Fix narrow Twitter timeline.

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -6,6 +6,6 @@ layout: default
   <div class="col-md-9">
     {{ content }}
   </div>
-  <div class="col-md-1">
+  <div class="col-md-3">
     <a class="twitter-timeline" data-width="220" data-height="2000" href="https://twitter.com/serg_delft?ref_src=twsrc%5Etfw">Tweets by serg_delft</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>  </div>
 </div>


### PR DESCRIPTION
AFAIK grid columns should add up to 12 for a row, so changed the width of the Twitter column to 12 - 9 = 3.